### PR TITLE
Add offline bundling helper for restricted networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,23 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+This README documents the steps to get the application up and running.
 
-Things you may want to cover:
+## Getting started
 
-* Ruby version
+1. Install the dependencies by running `bundle install`.
+2. Set up the database by running `rails db:setup`.
+3. Start the application server using `rails server`.
 
-* System dependencies
+## Offline installation
 
-* Configuration
+If your environment does not allow outbound internet traffic, you can rely on a
+pre-bundled cache of gems:
 
-* Database creation
+1. On a machine with internet access, run `bundle package --all` to populate a
+   `vendor/cache` directory containing the required `.gem` files.
+2. Copy that `vendor/cache` directory into this project (overwriting the empty
+   one if present).
+3. Run `bin/offline-bundle` to install the gems locally from the cache. The
+   command installs into `vendor/bundle` and avoids any network requests.
 
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
 # photoapp

--- a/bin/offline-bundle
+++ b/bin/offline-bundle
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$APP_ROOT"
+
+CACHE_DIR="$APP_ROOT/vendor/cache"
+
+if [ ! -d "$CACHE_DIR" ] || ! ls "$CACHE_DIR"/*.gem >/dev/null 2>&1; then
+  echo "No vendor/cache gem files found. Place cached .gem files under vendor/cache before running." >&2
+  exit 1
+fi
+
+bundle config set --local path "vendor/bundle"
+bundle config set --local deployment 'true'
+bundle install --local --jobs 4


### PR DESCRIPTION
## Summary
- add bin/offline-bundle helper to install gems from a pre-populated vendor/cache without network access
- document offline setup steps in the README to guide running in restricted environments

## Testing
- not run (bundle install requires outbound network access and is blocked in this environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ee953fbb08325852f2356edd425e5)